### PR TITLE
Add global comic sans effect.

### DIFF
--- a/dist/comic-sans.css
+++ b/dist/comic-sans.css
@@ -1,0 +1,6 @@
+/* We use this because Comic Sans isn't actually available on all OSs */
+@import url('https://fonts.googleapis.com/css?family=Architects+Daughter');
+
+* {
+	font-family: 'Architects Daughter', 'Comic Sans', 'Comic Sans MS', cursive !important;
+}

--- a/dist/falling-snow.js
+++ b/dist/falling-snow.js
@@ -37,11 +37,11 @@ jQuery( function( $ ) {
 				'left': x,
 				'position': 'fixed',
 				'top': y1,
-				'transform': 'scale(' + scaleFactor + ')',
+				'transform': 'scale(' + scaleFactor + ') rotate(' + rand( 0, 360 ) + 'deg)',
 				'z-index': 10000,
 			} )
 			.animate(
-				{ 'top' : '+=' + y2 },
+				{ 'top': '+=' + y2 },
 				speed,
 				removeSnow
 			)

--- a/src/Global_Effects.php
+++ b/src/Global_Effects.php
@@ -6,6 +6,10 @@ class Global_Effects {
 		if ( (bool) get_option( 'tribe_fools_falling_snow' ) ) {
 			add_action( 'wp_enqueue_scripts', [ $this,  'do_falling_snow' ] );
 		}
+
+		if ( (bool) get_option( 'tribe_fools_global_comic_sans' ) ) {
+			add_action( 'wp_enqueue_scripts', [ $this, 'do_comic_sans' ] );
+		}
 	}
 
 	public function do_falling_snow() {
@@ -29,6 +33,13 @@ class Global_Effects {
 					$img_url . '/snow-2.png'
 				]
 			]
+		);
+	}
+
+	public function do_comic_sans() {
+		wp_enqueue_style(
+			'tribe_fools_comic_sans',
+			main()->plugin_url() . '/dist/comic-sans.css'
 		);
 	}
 }


### PR DESCRIPTION
Actually pulls in a free Google Font (Architect's Daughter), because Comic Sans/Cursive may simply render as a simple sans serif on clean, modern distros like Mint.